### PR TITLE
Feat: OPX3.1-dev1

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -3,4 +3,5 @@ include_HEADERS=inc/hal_shell.h inc/nas_ndi_fc_stat.h  inc/nas_ndi_mac.h  inc/na
                 inc/nas_ndi_route.h inc/nas_ndi_switch.h inc/nas_ndi_common.h \
                 inc/nas_ndi_init.h inc/nas_ndi_plat_stat.h inc/nas_ndi_router_interface.h \
                 inc/nas_ndi_udf.h inc/nas_ndi_fc.h inc/nas_ndi_lag.h inc/nas_ndi_port.h \
-                inc/nas_ndi_sflow.h inc/nas_ndi_vlan.h inc/nas_ndi_l2mc.h inc/nas_ndi_mcast.h
+                inc/nas_ndi_sflow.h inc/nas_ndi_vlan.h inc/nas_ndi_l2mc.h inc/nas_ndi_mcast.h \
+                inc/nas_ndi_1d_bridge.h

--- a/configure.ac
+++ b/configure.ac
@@ -2,7 +2,7 @@
 # Process this file with autoconf to produce a configure script.
 
 AC_PREREQ([2.69])
-AC_INIT([opx-nas-ndi-api], [7.5.0], [ops-dev@lists.openswitch.net])
+AC_INIT([opx-nas-ndi-api], [7.7.0], [ops-dev@lists.openswitch.net])
 AM_INIT_AUTOMAKE([foreign])
 AM_MAINTAINER_MODE([enable])
 AC_CONFIG_SRCDIR([.])

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,20 @@
+opx-nas-ndi-api (7.7.0) unstable; urgency=medium
+
+  * Feature: Static L2 VxLAN Support
+  * Update: Use VLAN id for pv bridge port get
+  * Update: Add API to set bridge port attributes
+  * Update: Add support for virtual RIF attribute as part of RIF configuration
+  * Update: Add support for setting multicast lookup key in VLAN
+  * Update: Add APIs to clear statistics for bridge, bridge port, and tunnel
+  * Update: L2MAC changes for VxLAN, added API for .ID bridge
+  * Update: Add APIs for VxLAN stats, tunnel bridge port stats
+  * Update: Add APIs for L2MAC group add and delete API for LAG in 1d bridges
+  * Update: Add filter value for BRIDGE_TYPE
+  * Update: Add API to control tag/untag packet drop on LAG
+  * Update: Add support for ACL table utilization
+
+ -- Dell EMC <ops-dev@lists.openswitch.net>  Tue, 06 Nov 2018 14:49:02 -0800
+
 opx-nas-ndi-api (7.5.0) unstable; urgency=medium
 
   * Update: Added support for virtual rif attribute as part of RIF configuration.
@@ -52,7 +69,7 @@ opx-nas-ndi-api (6.6.0) unstable; urgency=medium
 opx-nas-ndi-api (5.5.0) unstable; urgency=medium
 
   * Update: Define NDI_RIF_MIN_MTU based on SAI MTU default for RIF
-  * Update: Allow the link local neighbor programming but with NO_HOST flag 
+  * Update: Allow the link local neighbor programming but with NO_HOST flag
            (just to create egress object for routes and not to create an entry in the host table)
   * Update: Added mac move event
   * Update: Update qos queue api's
@@ -67,7 +84,7 @@ opx-nas-ndi-api (5.5.0) unstable; urgency=medium
   * Feature: Added support to set Identification led ON/OFF
   * Bugfix: Miscellaneous bug fixes
   * Cleanup: Miscellaneous cleanup
- 
+
  -- Dell EMC <ops-dev@lists.openswitch.net>  Tue, 20 Jun 2017 14:49:02 -0800
 
 opx-nas-ndi-api (1.0.1) unstable; urgency=medium

--- a/inc/nas_ndi_1d_bridge.h
+++ b/inc/nas_ndi_1d_bridge.h
@@ -1,0 +1,442 @@
+/*
+ * Copyright (c) 2018 Dell Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * THIS CODE IS PROVIDED ON AN *AS IS* BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT
+ * LIMITATION ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS
+ * FOR A PARTICULAR PURPOSE, MERCHANTABLITY OR NON-INFRINGEMENT.
+ *
+ * See the Apache Version 2.0 License for specific language governing
+ * permissions and limitations under the License.
+ */
+
+
+/*
+ * nas_ndi_1d_bridge.h
+ */
+
+#ifndef _NAS_NDI_BRIDGE_D_H_
+#define _NAS_NDI_BRIDGE_D_H_
+
+#include "nas_ndi_common.h"
+#include "nas_ndi_stg.h"
+#include "dell-base-if-phy.h"
+
+#ifdef __cplusplus
+extern "C"{
+#endif
+
+
+/**
+ * @brief Create vlan unaware bridge 1d
+ *
+ * @param[in] npu_id - NPU ID
+ *
+ * @param[out] br_oid - created bridge id.
+ *
+ * @return STD_ERR_OK if operation is successful otherwise
+ *  error code is returned.
+ */
+
+t_std_error ndi_create_bridge_1d(npu_id_t npu_id, bridge_id_t *br_oid);
+
+
+/**
+ * @brief Delate vlan unaware bridge 1d
+ *
+ * @param[in] npu_id - NPU ID
+ *
+ * @param[in] br_oid - bridge id.
+ *
+ * @return STD_ERR_OK if operation is successful otherwise
+ *  error code is returned.
+ */
+
+t_std_error ndi_delete_bridge_1d(npu_id_t npu_id, bridge_id_t br_oid);
+
+
+/**
+ * @brief Gets Bridge Statistics
+ *
+ * @param[in] npu_id - NPU ID
+ *
+ * @param[in] br_oid - SAI Bridge Object ID
+ *
+ * @param[in] stats - array of Bridge counter ids
+ *
+ * @param[out] stats_val - statistics counter values
+ *
+ * @param[in] len - number of statistics to be queried
+ *
+ * @return STD_ERR_OK if operation is successful otherwise a different
+ *  error code is returned.
+ */
+
+t_std_error ndi_bridge_1d_stats_get(npu_id_t npu_id, bridge_id_t br_oid, ndi_stat_id_t *stats, uint64_t* stats_val, size_t len);
+
+/**
+ * @brief Clear Bridge statistics for a give bridge object id
+ *
+ * @param[in] npu_id - NPU ID
+ *
+ * @param[in] br_oid - SAI Bridge Object ID
+ *
+ * @param[in] stats - array of Bridge counter IDs
+ *
+ * @param[in] len - number of statistics to be cleared
+ *
+ * @return STD_ERR_OK if operation is successful otherwise a different
+ *  error code is returned.
+ */
+
+t_std_error ndi_bridge_1d_stats_clear(npu_id_t npu_id, bridge_id_t br_oid, ndi_stat_id_t *stats, size_t len);
+
+
+/**
+ * @brief Gets Bridge Port Statistics
+ *
+ * @param[in] npu_id - NPU ID
+ *
+ * @param port- npu port to get stats
+ *
+ * @param vlan_id - Vlan ID associated with the bridge port.
+ *
+ * @param[in] ndi_stat_ids - array of Bridge counter ids
+ *
+ * @param[out] stats_val - statistics counter values
+ *
+ * @param[in] len - number of statistics to be queried
+ *
+ * @return STD_ERR_OK if operation is successful otherwise a different
+ *  error code is returned.
+ */
+t_std_error ndi_bridge_port_stats_get(npu_id_t npu_id, npu_port_t port, hal_vlan_id_t vlan_id, ndi_stat_id_t *ndi_stat_ids, uint64_t* stats_val, size_t len);
+
+
+/**
+ * @brief Clear Bridge Port Statistics for a bridge port of given port and vlan id
+ *
+ * @param[in] npu_id - NPU ID
+ *
+ * @param port- npu port of the bridge port
+ *
+ * @param vlan_id - Vlan ID associated with the bridge port.
+ *
+ * @param[in] ndi_stat_ids - array of Bridge counter IDs
+ *
+ * @param[in] len - number of statistics to be cleared
+ *
+ * @return STD_ERR_OK if operation is successful otherwise a different
+ *  error code is returned.
+ */
+t_std_error ndi_bridge_port_stats_clear(npu_id_t npu_id, npu_port_t port, hal_vlan_id_t vlan_id,
+                                        ndi_stat_id_t *ndi_stat_ids, size_t len);
+
+/**
+ * @brief Gets Bridge Port Lag Statistics
+ *
+ * @param[in] npu_id - NPU ID
+ *
+ * @param lag_id - lag ID  to be added
+ *
+ * @param vlan_id - Vlan ID associated with the lag.
+ *
+ * @param[in] ndi_stat_ids - array of Bridge counter ids
+ *
+ * @param[out] stats_val - statistics counter values
+ *
+ * @param[in] len - number of statistics to be queried
+ *
+ * @return STD_ERR_OK if operation is successful otherwise a different
+ *  error code is returned.
+ */
+t_std_error ndi_lag_bridge_port_stats_get(npu_id_t npu_id, ndi_lag_id_t ndi_lag_id, hal_vlan_id_t vlan_id, ndi_stat_id_t *ndi_stat_ids, uint64_t* stats_val, size_t len);
+
+/**
+ * @brief Clear Bridge Port Statistics for a bridge port of given lag and vlan id
+ *
+ * @param[in] npu_id - NPU ID
+ *
+ * @param ndi_lag_id - LAG Id of the bridge port
+ *
+ * @param vlan_id - VLAN ID associated with the bridge port.
+ *
+ * @param[in] ndi_stat_ids - array of Bridge counter IDs
+ *
+ * @param[in] len - number of statistics to be cleared
+ *
+ * @return STD_ERR_OK if operation is successful otherwise a different
+ *  error code is returned.
+ */
+t_std_error ndi_lag_bridge_port_stats_clear(npu_id_t npu_id, ndi_lag_id_t ndi_lag_id, hal_vlan_id_t vlan_id,
+                                            ndi_stat_id_t *ndi_stat_ids, size_t len);
+
+/**
+ * @brief Gets Bridge Port tunnel Statistics
+ *
+ * @param[in] npu_id - NPU ID
+ *
+ * @param[in] bridge_oid - bridge ID
+ *
+ * @param[in] tunnel_params - combination of name value pair excepting tunnel config params like Src IP, Dest IP, vni
+ *
+ * @param[in] tp_len - number of tunnel_params
+ *
+ * @param[in] ndi_stat_ids - array of Bridge counter ids
+ *
+ * @param[out] stats_val - statistics counter values
+ *
+ * @param[in] len - number of statistics to be queried
+ *
+ * @return STD_ERR_OK if operation is successful otherwise a different
+ *  error code is returned.
+ */
+t_std_error ndi_tunnel_bridge_port_stats_get(npu_id_t npu_id, nas_bridge_id_t bridge_oid, nas_com_id_value_t tunnel_params[], size_t tp_len, ndi_stat_id_t *ndi_stat_ids, uint64_t* stats_val, size_t len);
+
+/**
+ * @brief Gets Tunnel Statistics
+ *
+ * @param[in] npu_id - NPU ID
+ *
+ * @param[in] tunnel_params - combination of name value pair excepting tunnel config params like Src IP, Dest IP, vni
+ *
+ * @param[in] tp_len - number of tunnel_params
+ *
+ * @param[in] ndi_stat_ids - array of Bridge counter ids
+ *
+ * @param[out] stats_val - statistics counter values
+ *
+ * @param[in] len - number of statistics to be queried
+ *
+ * @return STD_ERR_OK if operation is successful otherwise a different
+ *  error code is returned.
+ */
+t_std_error ndi_tunnel_stats_get(npu_id_t npu_id, nas_com_id_value_t tunnel_params[], size_t tp_len, ndi_stat_id_t *ndi_stat_ids, uint64_t* stats_val, size_t len);
+
+/**
+ * @brief Clear Tunnel Statistics for a given tunnel
+ *
+ * @param[in] npu_id - NPU ID
+ *
+ * @param[in] tunnel_params - tunnel local IP Address (  attr_id : TUNNEL_CLEAR_TUNNEL_STATS_INPUT_LOCAL_IP_ADDR,
+ *                                                       val     : hal_ip_addr_t structure)
+ *                          - tunnel remote IP Address ( attr_id : TUNNEL_CLEAR_TUNNEL_STATS_INPUT_remote_IP_ADDR,
+ *                                                       val     : hal_ip_addr_t structure)
+ *
+ * @param[in] tp_len - number of tunnel_params
+ *
+ * @param[in] ndi_stat_ids - array of Bridge counter IDs to be cleared
+ *
+ * @param[in] len - number of statistics to be cleared
+ *
+ * @return STD_ERR_OK if operation is successful otherwise a different
+ *  error code is returned.
+ */
+t_std_error ndi_tunnel_stats_clear(npu_id_t npu_id, nas_com_id_value_t tunnel_params[], size_t tp_len,
+                                   ndi_stat_id_t *ndi_stat_ids, size_t len);
+
+/**
+ * @brief Add ports to 1d bridge
+ *
+ * @param npu_id - NPU ID
+ *
+ * @param br_oid - bridge id.
+ *
+ * @param port- npu port to be added
+ *
+ * @param vlan_id - Vlan ID associated with the port.(P,V)
+ *
+ * @param tag -True if the port is tagged.
+ *
+ * @return STD_ERR_OK if operation is successful otherwise a different
+ *  error code is returned.
+ */
+
+t_std_error ndi_1d_bridge_member_port_add(npu_id_t npu_id, bridge_id_t br_oid , npu_port_t port, hal_vlan_id_t  vlan_id, bool tag);
+
+
+/**
+ * @brief Delete port from 1d bridge.
+ *
+ * @param npu_id - NPU ID
+ *
+ * @param port- npu port to be deleted
+ *
+ * @param vlan_id - Vlan ID associated with the port.(P,V)
+ *
+ * @return STD_ERR_OK if operation is successful otherwise a different
+ *  error code is returned.
+ */
+
+t_std_error ndi_1d_bridge_member_port_delete(npu_id_t npu_id, npu_port_t port, hal_vlan_id_t  vlan_id);
+
+
+/**
+ * @brief Add lag to 1d bridge
+ *
+ * @param npu_id - NPU ID
+ *
+ * @param br_oid - bridge id.
+ *
+ * @param lag_id - lag ID  to be added
+ *
+ * @param vlan_id - Vlan ID associated with the lag.
+ *
+ * @param tag - True if the lag is tagged.
+ *
+ * @return STD_ERR_OK if operation is successful otherwise a different
+ *  error code is returned.
+ */
+
+t_std_error ndi_1d_bridge_member_lag_add(npu_id_t npu_id, bridge_id_t br_oid , ndi_lag_id_t lag_id, hal_vlan_id_t  vlan_id, bool tag);
+
+
+/**
+ * @brief Delete lag from 1d bridge.
+ *
+ * @param npu_id - NPU ID
+ *
+ * @param lag_id - lag_id of the lag to be removed from 1d bridge
+ *
+ * @param vlan_id - Vlan ID associated with the lag.
+ *
+ * @return STD_ERR_OK if operation is successful otherwise a different
+ *  error code is returned.
+ */
+
+t_std_error ndi_1d_bridge_member_lag_delete(npu_id_t npu_id, ndi_lag_id_t lag_id, hal_vlan_id_t  vlan_id);
+
+/**
+ * @brief Create underlay rif.
+ *
+ * @param npu_id[in] - NPU ID
+ *
+ * @param underlay_rif_oid[out]- OID of underlay_rif created.
+ *
+ * @param vr_oid[in] -Virtual router id.
+ *
+ * @return STD_ERR_OK if operation is successful otherwise a different
+ *  error code is returned.
+ */
+
+
+t_std_error ndi_create_underlay_rif(npu_id_t npu_id, ndi_obj_id_t *underlay_rif_oid, ndi_obj_id_t vr_oid);
+
+
+/**
+ * @brief Add remote end point.
+ *
+ * @param[in] npu_id - NPU ID
+ *
+ * @param[in] bridge_oid - bridge ID
+ *
+ * @param[in] tunnel_params - combination of name value pair accepting tunnel config params like Src IP, Dest IP, vni using CPS attribute
+ *
+ * @param[in] len - number of tunnel_params
+ *
+ * @param[in]  cus_param - name value pair to send bridge, vrf and rif oid  .
+ *
+ *@param[out] cus_len - number of cus_params
+ *
+ * @return STD_ERR_OK if operation is successful otherwise a different
+ *  error code is returned.
+ */
+
+
+t_std_error nas_ndi_add_remote_endpoint(npu_id_t npu_id, nas_com_id_value_t tunnel_params[], size_t len,
+nas_custom_id_value_t cus_param[], size_t cus_len, ndi_obj_id_t *tun_brport_oid);
+
+/**
+ * @brief Delete remote end point.
+ *
+ * @param[in] npu_id - NPU ID
+ *
+ * @param[in] bridge_oid - bridge ID
+ *
+ * @param[in] tunnel_params - combination of name value pair excepting tunnel config params like Src IP, Dest IP, vni
+ *
+ * @param[in] len - number of tunnel_params
+ *
+ * @return STD_ERR_OK if operation is successful otherwise a different
+ *  error code is returned.
+ */
+
+
+t_std_error nas_ndi_remove_remote_endpoint(npu_id_t npu_id, nas_bridge_id_t bridge_oid, nas_com_id_value_t tunnel_params[], size_t len);
+
+/**
+ * @brief flood control on 1d bridge for unknown dest mac Packet.
+ *
+ * @param[in] npu_id - NPU ID
+ *
+ * @param[in] bridge_oid - bridge ID
+ *
+ * @param[in] multicast_grp - L2MC group of the bridge.
+ *
+ * @param[in] pkt_type - packet types : unicast, multicast, broadcast or all
+ *
+ * @param[in] enable_flood- enable  flooding of the unknown packets in 1d BRIDGE.
+ *
+ * @return STD_ERR_OK if operation is successful otherwise a different
+ *  error code is returned.
+ */
+
+t_std_error ndi_flood_control_1d_bridge(npu_id_t npu_id, ndi_obj_id_t br_oid,  ndi_obj_id_t multicast_grp,
+           ndi_bridge_packets_type_t pkt_type, bool enable_flood);
+
+/**
+ * @breif Set the tunnel bridge port's MAC Learning Mode.
+ *
+ * @param[in] npu_id - NPU ID
+ *
+ * @param[in] tun_brport - tunnel bridge port  ID
+ *
+ * @param[in] mode -  MAC learn mode to be set for tunnel bridge port
+ *
+ * @return STD_ERR_OK if operation is successful otherwise a different
+ *  error code is returned.
+ */
+t_std_error ndi_tunport_mac_learn_mode_set(npu_id_t npu_id, ndi_obj_id_t tun_brport,
+                                        BASE_IF_PHY_MAC_LEARN_MODE_t mode);
+
+
+
+/**
+ * @brief Set the attributes for bridge sub port
+ *
+ * @param[in] npu_id - NPU ID
+ *
+ * @param[in] port_id - Port ID which could be physical port id or lag object id
+ *
+ * @param[in] port_type -  Port type which is of type ndi_port_type_t
+ *
+ * @param[in] vlan_id - VLAN ID of the sub port
+ *
+ * @param[in] attribute_key_val - array of attribute id (key) and its value
+ *
+ * Following attributes are supported currently
+ *
+ * Attribute Id                                 type
+ * DELL_IF_IF_INTERFACES_INTERFACE_MAC_LEARN -  BASE_IF_MAC_LEARN_MODE_t (uint32_t)
+ *
+ *
+ * @param[in] key_val_size - size of the attribute_key_val array
+ *
+ * @return STD_ERR_OK if operation is successful otherwise a different
+ *  error code is returned.
+ *
+ */
+
+t_std_error ndi_bridge_sub_port_attr_set(npu_id_t npu_id, ndi_obj_id_t port_id,ndi_port_type_t port_type,
+                                         hal_vlan_id_t vlan_id,
+                                         nas_com_id_value_t attribute_key_val[], size_t key_val_size);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  /*   _NAS_NDI_BRIDGE_D_H_*/

--- a/inc/nas_ndi_acl.h
+++ b/inc/nas_ndi_acl.h
@@ -43,6 +43,23 @@ extern "C" {
  */
 typedef  uint32_t   ndi_acl_priority_t;
 typedef  uint16_t   ndi_acl_l4_port_t;
+
+/**
+ * @brief ACL Table data structure passed from NAS to NDI
+ * Contains data for ACL Table provisioning in SAI.
+ */
+typedef struct _ndi_acl_slice_attr {
+    uint32_t                slice_index;
+    uint32_t                pipeline_index;
+    size_t                  used_count;
+    size_t                  avail_count;
+    BASE_ACL_STAGE_t        stage;
+
+    //list of acl table object id's returned as part of get
+    size_t                  acl_table_count;
+    ndi_obj_id_t           *acl_table_list;
+} ndi_acl_slice_attr_t;
+
 /**
  * @brief ACL Table data structure passed from NAS to NDI
  * Contains data for ACL Table provisioning in SAI.
@@ -58,6 +75,25 @@ typedef struct _ndi_acl_table {
     size_t                  action_count;
     BASE_ACL_ACTION_TYPE_t *action_list;
 } ndi_acl_table_t;
+
+
+/**
+ * @brief ACL Table attribute data structure passed from NDI to NAS
+ * Contains data for ACL Table attributes retrieved from SAI.
+ */
+typedef struct _ndi_acl_table_attr {
+
+    //list of acl table used entry count returned as part of get
+    //each entry in this list represent the count for one pipeline.
+    size_t                  acl_table_used_entry_list_count;
+    uint32_t               *acl_table_used_entry_list;
+
+    //list of acl table available entry count returned as part of get
+    //each entry in this list represent the count for one pipeline.
+    size_t                  acl_table_avail_entry_list_count;
+    uint32_t               *acl_table_avail_entry_list;
+} ndi_acl_table_attr_t;
+
 
 /**
  * @brief Type associated with the union data in ndi_acl_entry_filter_t.
@@ -77,6 +113,7 @@ typedef enum {
     NDI_ACL_FILTER_OBJ_ID_LIST,
     NDI_ACL_FILTER_BOOL,
     NDI_ACL_FILTER_U8LIST,
+    NDI_ACL_FILTER_BRIDGE_TYPE,
 } ndi_acl_filter_values_type_t;
 
 /**
@@ -483,6 +520,34 @@ t_std_error ndi_acl_range_create(npu_id_t npu_id, const ndi_acl_range_t *acl_ran
  *  error code is returned.
  */
 t_std_error ndi_acl_range_delete(npu_id_t npu_id, ndi_obj_id_t ndi_range_id);
+
+/**
+ * @brief Retrieve existing ACL Slice usage information
+ *
+ * @param npu_id - NPU ID in which to retrieve
+ * @param slice_id - NDI ID of ACL Slice to be retrieved.
+ * @param[out] slice_attr - ACL Slice attribute information returned from NDI.
+ *
+ * @return STD_ERR_OK if operation is successful otherwise a different
+ *  error code is returned.
+ */
+
+t_std_error ndi_acl_get_slice_attribute (npu_id_t npu_id, ndi_obj_id_t slice_id,
+                                         ndi_acl_slice_attr_t *slice_attr);
+
+/**
+ * @brief Retrieve existing ACL Table usage information
+ *
+ * @param npu_id - NPU ID in which to retrieve
+ * @param table_id - NDI ID of ACL Table to be retrieved.
+ * @param[out] table_attr - ACL Table attribute information returned from NDI.
+ *
+ * @return STD_ERR_OK if operation is successful otherwise a different
+ *  error code is returned.
+ */
+
+t_std_error ndi_acl_get_acl_table_attribute (npu_id_t npu_id, ndi_obj_id_t table_id,
+                                             ndi_acl_table_attr_t *table_attr);
 
 /**
  * \}

--- a/inc/nas_ndi_common.h
+++ b/inc/nas_ndi_common.h
@@ -52,6 +52,7 @@ extern "C" {
  * BASE_STATS_INTERFACE_IF_t
  */
 typedef uint64_t ndi_stat_id_t;
+typedef uint64_t bridge_id_t;
 
 /**
  * @class NDI Switch operational Status
@@ -64,6 +65,50 @@ typedef enum _ndi_switch_oper_status_t
    NDI_SWITCH_OPER_DOWN,
    NDI_SWITCH_OPER_FAILED,
 } ndi_switch_oper_status_t;
+
+typedef enum _ndi_bridge_packets_type
+{
+    NDI_BRIDGE_PKT_UNICAST,
+    NDI_BRIDGE_PKT_MULTICAST,
+    NDI_BRIDGE_PKT_BROADCAST,
+    NDI_BRIDGE_PKT_ALL
+} ndi_bridge_packets_type_t;
+
+
+typedef enum nas_1d_param
+{
+    VRF_OID,
+    UNDERLAY_OID,
+    BRIDGE_OID,
+} nas_1d_param_t;
+
+/**
+ * Type of packets that would be discarded by NPU port
+ */
+typedef enum {
+    NDI_PORT_DROP_UNTAGGED,     /* Port will discard all untagged packets */
+    NDI_PORT_DROP_TAGGED        /* Port will discard all tagged packets */
+} ndi_port_drop_mode_t;
+
+
+
+typedef enum ndi_port_type{
+    ndi_port_type_PORT=1,
+    ndi_port_type_LAG,
+}ndi_port_type_t;
+
+/* Common typedef for passing id-value pair */
+typedef struct entry {
+    nas_attr_id_t attr_id;
+    void *val;
+    size_t vlen;
+} nas_com_id_value_t;
+
+typedef struct nas_custom_id_value {
+    nas_1d_param_t attr_id;
+    void *val;
+    size_t vlen;
+} nas_custom_id_value_t;
 
 /**
  * @class NDI Port operational Status
@@ -120,6 +165,11 @@ typedef enum _ndi_packet_trap_id_t{
     NDI_PACKET_TRAP_ID_SAMPLEPACKET,
     NDI_PACKET_TRAP_ID_L3_MTU_ERROR
 }ndi_packet_trap_id_t;
+
+typedef struct vrf_underlay_rif {
+    ndi_obj_id_t vrf_oid;
+    ndi_obj_id_t underlay_rif_id;
+}vrf_underlay_rif_t;
 
 
 /**

--- a/inc/nas_ndi_l2mc.h
+++ b/inc/nas_ndi_l2mc.h
@@ -90,6 +90,49 @@ t_std_error ndi_l2mc_group_add_lag_member(npu_id_t npu_id,
                                            ndi_obj_id_t group_id, ndi_obj_id_t lag_id,
                                            ndi_obj_id_t *member_id_p);
 
+
+/**
+ * @brief Add or delete tunnel port to L2MC Group
+ *
+ * @param npu_id - NPU ID in which to add multicast group member
+ * @param group_id - L2MC Group ID to which tunnel port will be added or deleted.
+ * @param tun_brport_id - Tunnel port's OID .
+ * @param add - true for addtion, false for deletion.
+ * @return STD_ERR_OK if operation is successful otherwise a different
+ *  error code is returned.
+ */
+t_std_error ndi_l2mc_handle_tunnel_member(npu_id_t npu_id,
+     ndi_obj_id_t group_id, ndi_obj_id_t tun_brport_id, hal_ip_addr_t *rem_ip, bool add);
+
+
+/**
+ * @brief Add or delete lag to L2MC Group
+ *
+ * @param npu_id - NPU ID in which to add multicast group member
+ * @param group_id - L2MC Group ID to which sub port will be added or deleted.
+ * @param lag_id - Lag ID
+ * @param vid - vlan id of the Sub port
+ * @param add - true for addtion, false for deletion.
+ * @return STD_ERR_OK if operation is successful otherwise a different
+ *  error code is returned.
+ */
+
+t_std_error ndi_l2mc_handle_lagport_add (npu_id_t npu_id,
+     ndi_obj_id_t group_id, ndi_obj_id_t lag_id, hal_vlan_id_t vid, bool add);
+/**
+ * @brief Add or delete sub port to L2MC Group
+ *
+ * @param npu_id - NPU ID in which to add multicast group member
+ * @param group_id - L2MC Group ID to which sub port will be added or deleted.
+ * @param port_id - Sub port's ID
+ * @param vid - vlan id of the Sub port
+ * @param add - true for addtion, false for deletion.
+ * @return STD_ERR_OK if operation is successful otherwise a different
+ *  error code is returned.
+ */
+
+t_std_error ndi_l2mc_handle_subport_add (npu_id_t npu_id,
+           ndi_obj_id_t group_id, port_t port_id, hal_vlan_id_t vid, bool add);
 /**
  * @brief Delete an existing member from L2MC Group
  *

--- a/inc/nas_ndi_lag.h
+++ b/inc/nas_ndi_lag.h
@@ -149,6 +149,19 @@ t_std_error ndi_set_lag_learn_mode(npu_id_t npu_id, ndi_obj_id_t ndi_lag_id,
         BASE_IF_MAC_LEARN_MODE_t mode);
 
 /**
+ * This function is used to enable/disable tagged or untagged packet drop mode
+ * for specific Lag
+ * @param npu_id NPU ID
+ * @param lag_id Lag ID
+ * @param mode packet drop mode
+ * @enable enable or disable packet drop mode
+ * @return standard error
+ */
+
+t_std_error ndi_lag_set_packet_drop(npu_id_t npu_id, ndi_obj_id_t ndi_lag_id,
+                                     ndi_port_drop_mode_t mode, bool enable);
+
+/**
 @}
 */
 

--- a/inc/nas_ndi_mac.h
+++ b/inc/nas_ndi_mac.h
@@ -35,138 +35,175 @@ extern "C" {
  *  \{
  */
 
-/*
- * Attribute flags for mac entry related info
- *
- * Contains different attribute flags
- *
+
+/**
+ * @brief MAC entry type to determine which type of flooding domain it belongs to
+ */
+typedef enum{
+    NDI_MAC_ENTRY_TYPE_1Q,              /** MAC entry belongs to VLAN aware flooding domain */
+    NDI_MAC_ENTRY_TYPE_1D_LOCAL,        /** MAC entry belongs to 1D bridge and is local */
+    NDI_MAC_ENTRY_TYPE_1D_REMOTE,       /** MAC entry belongs to 1D bridge and is remote */
+}ndi_mac_entry_type_t;
+
+
+
+/**
+ * @brief MAC entry attributes flag to be used when updating the MAC address entry
  */
 typedef enum {
-    NDI_MAC_ENTRY_ATTR_TYPE        = 1,     /* static/dynamic */
-    NDI_MAC_ENTRY_ATTR_PORT_ID,             /* port id */
-    NDI_MAC_ENTRY_ATTR_PKT_ACTION,          /* packet action */
+    NDI_MAC_ENTRY_ATTR_TYPE=1,              /** MAC entry type static/dynamic */
+    NDI_MAC_ENTRY_ATTR_PORT_ID,             /** Port ID associated with entry  */
+    NDI_MAC_ENTRY_ATTR_PKT_ACTION,          /** Packet action when this MAC entry is hit */
+    NDI_MAC_ENTRY_ATTR_ENDPOINT_IP,         /** Remote endpoint IP for MAC entry only
+                                                applicable for NDI_MAC_ENTRY_TYPE_1D_REMOTE*/
     NDI_MAC_ENTRY_ATTR_MAX
 } ndi_mac_attr_flags;
 
-/*
- * L2 MAC entry
+
+/**
+ *@brief  MAC entry struct which contains attributes to create/update/delete
+ *@brief  MAC address entries.
  *
- * Contains details of signle mac entry
- *
+ * Depending on the type of the mac_entry_type and the type of operation
+ * (create/update/delete) some of the attributes are mandatory. Each function
+ * lists the attributes which it is expecting
  */
 
 typedef struct ndi_mac_entry_s {
-    npu_id_t                    npu_id;     /* NPU ID */
-    hal_vlan_id_t               vlan_id;    /* VLAN ID */
-    ndi_port_t                  port_info;  /* NDI port (npu/local port) */
-    hal_mac_addr_t              mac_addr;   /* MAC address */
-    bool                        is_static;  /* Flag to determine static/dynamic */
-    BASE_MAC_PACKET_ACTION_t    action;     /* Packet action */
-    ndi_mac_attr_flags          attr_flag;  /* Attribute flag */
-    uint64_t                    ndi_lag_id; /* In case of lag, ndi lag id is used by mac
-                                             * to decode the ifindex */
+    npu_id_t                    npu_id;          /** NPU ID */
+    hal_vlan_id_t               vlan_id;         /** VLAN ID */
+    ndi_port_t                  port_info;       /** NDI port (npu/local port) */
+    hal_mac_addr_t              mac_addr;        /** MAC address */
+    bool                        is_static;       /** Flag to determine static/dynamic */
+    BASE_MAC_PACKET_ACTION_t    action;          /** Packet action */
+    ndi_mac_attr_flags          attr_flag;       /** Attribute flag */
+    uint64_t                    ndi_lag_id;      /** When MAC entry belongs to LAG */
+    uint64_t                    bridge_id;       /** 1D Bridge ID */
+    uint64_t                    endpoint_ip_port;/** Endpoint IP port */
+    hal_ip_addr_t               endpoint_ip;     /** Remote end-point IP */
+    ndi_mac_entry_type_t        mac_entry_type;  /** To indicate what type of MAC entry is being
+                                                     programmed. Default is NDI_MAC_ENTRY_TYPE_1Q */
 } ndi_mac_entry_t;
 
-/*
- * Attribute flag for MAC entry delete
- *
- * Contains various types of MAC entry delete
- *
+
+/**
+ * @brief To determine MAC delete operation type
  */
 typedef enum {
-    NDI_MAC_DEL_SINGLE_ENTRY    = 1,    /* Delete single entry */
-    NDI_MAC_DEL_BY_PORT,                /* Delete all the entries by port */
-    NDI_MAC_DEL_BY_VLAN,                /* Delete all the entries by vlan */
-    NDI_MAC_DEL_BY_PORT_VLAN,           /* Delete all the entries by port/vlan combination */
-    NDI_MAC_DEL_ALL_ENTRIES,            /* Delete all the entries */
+    NDI_MAC_DEL_SINGLE_ENTRY=1,        /** Delete single entry */
+    NDI_MAC_DEL_BY_PORT,               /** Delete all the entries by port */
+    NDI_MAC_DEL_BY_VLAN,               /** Delete all the entries by vlan */
+    NDI_MAC_DEL_BY_PORT_VLAN,          /** Delete all the entries by port/vlan combination */
+    NDI_MAC_DEL_BY_BRIDGE,             /** Delete all the entries by 1D bridge id */
+    NDI_MAC_DEL_BY_BRIDGE_ENDPOINT_IP, /** Delete all the entries by vni */
+    NDI_MAC_DEL_ALL_ENTRIES,           /** Delete all the entries */
+    NDI_MAC_DEL_BY_PORT_VLAN_SUBPORT,  /** Delete all the entries by port vlan subport */
     NDI_MAC_DEL_INVALID_TYPE
 } ndi_mac_delete_type_t;
 
-/*
- * Attribute flag for MAC entry change event
- *
- * Contains MAC entry change event details, depending on this uppper layer
- * will update the cache
+
+/**
+ *@brief To determine the MAC entry event type when MAC entry notification is
+ *@brief given from below layer
  *
  */
 typedef enum {
-    NDI_MAC_EVENT_LEARNED   = 1,    /* New MAC entry learned */
-    NDI_MAC_EVENT_AGED,             /* MAC entry aged */
-    NDI_MAC_EVENT_FLUSHED,          /* MAC entry removed */
-    NDI_MAC_EVENT_MOVED,            /* MAC entry moved */
+    NDI_MAC_EVENT_LEARNED   = 1,    /** New MAC entry learned */
+    NDI_MAC_EVENT_AGED,             /** MAC entry aged */
+    NDI_MAC_EVENT_FLUSHED,          /** MAC entry removed */
+    NDI_MAC_EVENT_MOVED,            /** MAC entry moved */
     NDI_MAC_EVENT_INVALID
 } ndi_mac_event_type_t;
 
-/**
- * @brief Add a MAC entry into the MAC Table
- *
- * @param entry - MAC entry to be configured
- *
- * @return STD_ERR_OK if operation is successful otherwise a different
- *  error code is returned.
- */
-t_std_error ndi_create_mac_entry(ndi_mac_entry_t *entry);
-t_std_error ndi_update_mac_entry(ndi_mac_entry_t *p_mac_entry, ndi_mac_attr_flags attr_changed);
 
 /**
- * @brief Delete MAC entry/entries from the MAC Table based on delete_type flag
+ * @brief Add a new MAC address entry into the MAC Table
+ * @param entry - MAC address entry to be configured
  *
- * @param entry - entry to be deleted. delete_flag will determine which
- *                elements of this structure to be considered
- *                e.g.
- *                for SINGLE_ENTRY, all the fields within entry should be considered.
- *                for ALL_ENTRIES, this param is ignored.
+ * Mandatory attributes
  *
- * @param delete_type - flag to indicate the type (single/port/port-vlan/vlan/all)
+ * mac_entry_type                    attributes
+ * NDI_MAC_ENTRY_TYPE_1Q             vlan_id,mac_addr and port_info/ndi_lag_id
+ * NDI_MAC_ENTRY_TYPE_1D_LOCAL       bridge_id,mac_addr and port_info/ndi_lag_id
+ * NDI_MAC_ENTRY_TYPE_1D_REMOTE      vni,mac_addr and endpoint_ip
  *
+ * @return - STD_ERR_OK if operation is successful otherwise a different error code is returned.
+ */
+t_std_error ndi_create_mac_entry(ndi_mac_entry_t *entry);
+
+
+/**
+ * @brief Update existing MAC Address entry attributes
+ * @param entry - MAC entry containing the key and new attributes that needs to be updated
+ * @param attr_changed - flag to indicate which attribute in the MAC entry needs to be updated
+ *
+ * Mandatory attributes
+ *
+ * mac_entry_type                    attributes
+ * NDI_MAC_ENTRY_TYPE_1Q             vlan_id,mac_addr
+ * NDI_MAC_ENTRY_TYPE_1D_LOCAL       bridge_id,mac_addr
+ * NDI_MAC_ENTRY_TYPE_1D_REMOTE      vni,mac_addr
+ *
+ * @return - STD_ERR_OK if operation is successful otherwise a different error code is returned.
+ */
+t_std_error ndi_update_mac_entry(ndi_mac_entry_t * entry, ndi_mac_attr_flags attr_changed);
+
+
+/**
+ * @brief Delete MAC entry/entries  based on delete_type flag
+ * @param entry - MAC entry containing attributes to be deleted based on the delete_flag
+ * @param delete_type - flag to indicate the type (single/port/port-vlan/vlan/bridge/vni/vni-ip/all)
  * @param type_set - flag to indicate whether all entries needs to be flushed under the type.
  *                   If this is not set all entries(static/dynamic) should be flushed.
  *
- * @return STD_ERR_OK if operation is successful otherwise a different
- *  error code is returned.
+ * Mandatory attributes
+ *
+ * delete_type                        attributes
+ * NDI_MAC_DEL_SINGLE_ENTRY           mac_addr/vlan_id,mac_addr/bridge_id
+ * NDI_MAC_DEL_BY_PORT,               port_info
+ * NDI_MAC_DEL_BY_VLAN,               vlan_id
+ * NDI_MAC_DEL_BY_PORT_VLAN           port_info/vlan_id
+ * NDI_MAC_DEL_BY_BRIDGE              bridge_id
+ * NDI_MAC_DEL_BY_BRIDGE_ENDPOINT_IP  bridge_id/endpoint ip
+ * NDI_MAC_DEL_ALL_ENTRIES            none
+ *
+ * @return - STD_ERR_OK if operation is successful otherwise a different error code is returned.
  */
 t_std_error ndi_delete_mac_entry(ndi_mac_entry_t *entry, ndi_mac_delete_type_t delete_type, bool type_set);
 
+
 /**
- * @brief   MAC event notification callback function type
+ * @brief   MAC entry event notification callback function type
  * @param   npu_id NPU ID
  * @param   ndi_mac_event_type_t event type
- * @param   ndi_mac_entry_t mac entry details
+ * @param   ndi_mac_entry_t MAC entry details
  * @return  None
  */
 typedef void (*ndi_mac_event_notification_fn) (npu_id_t npu_id, ndi_mac_event_type_t mac_event, ndi_mac_entry_t *mac_entry, bool is_lag_index);
 
+
 /**
  * @brief This function is used to register the callback function for MAC event notification with NDI
- *
  * @param reg_fn - Callback function for MAC event notification
- *
- * @return STD_ERR_OK if operation is successful otherwise a different
- *  error code is returned.
+ * @return STD_ERR_OK if operation is successful otherwise a different error code is returned.
  */
 t_std_error ndi_mac_event_notify_register(ndi_mac_event_notification_fn reg_fn);
 
+
 /**
  * @brief Retrieve the MAC entry
- *
  * @param mac_entry - Caller to fill up the mandatory fields into this entry
  *                    i.e. npu_id, vlan_id, mac_addr
  *                    This entry will be filled up with further details after successful execution
  *                    i.e. port_id, action, is_static
- *
- * @return STD_ERR_OK if operation is successful otherwise a different
- *  error code is returned.
+ * @return STD_ERR_OK if operation is successful otherwise a different error code is returned.
  */
 t_std_error ndi_get_mac_entry_attr(ndi_mac_entry_t *mac_entry);
 
 
 /**
- * @brief Set MAC entry
- *
- * @param mac_entry - entry to be set
- *
- * @return STD_ERR_OK if operation is successful otherwise a different
- *  error code is returned.
+ * @deprecated - This method is deprecated and should not be used.
+ * @brief This is an empty function which shall be removed.
  */
 t_std_error ndi_set_mac_entry_attr(ndi_mac_entry_t *mac_entry);
 

--- a/inc/nas_ndi_port.h
+++ b/inc/nas_ndi_port.h
@@ -38,13 +38,6 @@ extern "C" {
  *  \{
  */
 
-/**
- * Type of packets that would be discarded by NPU port
- */
-typedef enum {
-    NDI_PORT_DROP_UNTAGGED,     /* Port will discard all untagged packets */
-    NDI_PORT_DROP_TAGGED        /* Port will discard all tagged packets */
-} ndi_port_drop_mode_t;
 
 /**
  * This function register port link state callback function with NDI.

--- a/inc/nas_ndi_switch.h
+++ b/inc/nas_ndi_switch.h
@@ -25,6 +25,7 @@
 
 #include "std_error_codes.h"
 #include "ds_common_types.h"
+#include "nas_types.h"
 
 #include "dell-base-switch-element.h"
 #include <vector>
@@ -33,6 +34,11 @@
 extern "C" {
 #endif
 
+//////////////////////////////////////////////////////////
+//Utilities to convert IDs from NDI to SAI and vice-versa
+/////////////////////////////////////////////////////////
+#define ndi_acl_ndi2sai_slice_id(x)         (sai_object_id_t) (x)
+#define ndi_acl_sai2ndi_slice_id(x)         (ndi_obj_id_t) (x)
 
 /**
  * This union holds all of the possible types used to communicate with the switch
@@ -48,6 +54,10 @@ typedef union {
         uint32_t *     vals;
         size_t         len;
     } list;
+    struct {
+        size_t         len;
+        ndi_obj_id_t *  vals;
+    } obj_list;
     hal_mac_addr_t mac;
 } nas_ndi_switch_param_t ;
 
@@ -137,6 +147,14 @@ t_std_error ndi_switch_get_queue_numbers(npu_id_t npu_id,
  */
 t_std_error ndi_switch_get_max_number_of_scheduler_group_level(npu_id_t npu_id,
                         uint32_t *max_level);
+
+/**
+ * @brief Retrieve switch ACL slice list
+ * @param npu_id - NPU id
+ * @param [out] max_level - max number of levels in HQoS hierarchy
+ * @return STD_ERR_OK on success
+ */
+t_std_error ndi_switch_get_slice_list(npu_id_t npu_id, nas_ndi_switch_param_t *param);
 
 #ifdef __cplusplus
 }

--- a/src/unit_test/nas_ndi_api_port_ut.cpp
+++ b/src/unit_test/nas_ndi_api_port_ut.cpp
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2018 Dell Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * THIS CODE IS PROVIDED ON AN *AS IS* BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT
+ * LIMITATION ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS
+ * FOR A PARTICULAR PURPOSE, MERCHANTABLITY OR NON-INFRINGEMENT.
+ *
+ * See the Apache Version 2.0 License for specific language governing
+ * permissions and limitations under the License.
+ */
+
+/*
+ * nas_ndi_api_port_ut.cpp
+ *
+ */
+
+#include "nas_ndi_port.h"
+#include "gtest/gtest.h"
+
+t_std_error ndi_port_set_packet_drop(npu_id_t npu_id, npu_port_t port_id,
+                                     ndi_port_drop_mode_t mode, bool enable)
+{
+    printf("Entering function %s\n", __FUNCTION__);
+    return STD_ERR_OK;
+}
+
+TEST(nas_ndi_port, set_port_drop_mode)
+{
+    ASSERT_TRUE(ndi_port_set_packet_drop(0, 1, NDI_PORT_DROP_UNTAGGED, true) == STD_ERR_OK);
+    ASSERT_TRUE(ndi_port_set_packet_drop(0, 1, NDI_PORT_DROP_TAGGED, false) == STD_ERR_OK);
+}
+
+int main(int argc, char *argv[])
+{
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/src/unit_test/nas_ndi_api_qos_ut.cpp
+++ b/src/unit_test/nas_ndi_api_qos_ut.cpp
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2016 Dell Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * THIS CODE IS PROVIDED ON AN *AS IS* BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT
+ * LIMITATION ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS
+ * FOR A PARTICULAR PURPOSE, MERCHANTABLITY OR NON-INFRINGEMENT.
+ *
+ * See the Apache Version 2.0 License for specific language governing
+ * permissions and limitations under the License.
+ */
+
+/*
+ * filename: nas_ndi_qos_ut.cpp
+ */
+
+#include "nas_ndi_qos.h"
+#include "gtest/gtest.h"
+
+TEST(nas_ndi_api, nas_ndi_qos)
+{
+
+    printf("Testing Compilation OK.\n");
+
+}
+
+
+int main(int argc, char **argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/src/unit_test/run_test
+++ b/src/unit_test/run_test
@@ -1,0 +1,4 @@
+#!/bin/bash -e
+
+./nas_ndi_api_qos_ut
+./nas_ndi_api_port_ut


### PR DESCRIPTION
* Feature: VxLAN Support
  * Update: Use vlan id for pv bridge port get
  * Update: Add API to set bridge port attributes
  * Update: Add support for virtual rif attribute as part of RIF configuration
  * Update: Add support for setting multicast lookup key in VLAN
  * Update: Add APIs to clear statistics for bridge,bridge port and tunnel
  * Update: L2MAC chagnes for vxlan, added API for .ID bridg
  * Update: Add APIs for VXLAN stats, tunnel bridge port stats
  * Update: Add APIs for l2mc group add and delete API for lag in 1d bridges
  * Update: Add filter value for BRIDGE_TYPE
  * Update: Add API to control tag/untag packet drop on LAG
  * Update: Add support for ACL table utilization

Signed-off-by: Garrick He <garrick_he@dell.com>